### PR TITLE
Migrate plugin to support freezed v3 by updating generated class syntax

### DIFF
--- a/src/main/java/com/justprodev/json_to_freezed/generator/Generator.kt
+++ b/src/main/java/com/justprodev/json_to_freezed/generator/Generator.kt
@@ -46,7 +46,7 @@ class Generator(private val settings: SettingsData) {
         with(entity) {
             // class
             append("@freezed\n")
-            append("class $type with _\$$type {\n")
+            append("abstract class $type with _\$$type {\n")
 
             // constructor
             append("  const factory $type(")


### PR DESCRIPTION
### Summary : #1

Raised Issue : #1

This PR updates the class generation logic to be compatible with `freezed` v3. Specifically, it modifies the output to declare generated classes as `abstract`, aligning with the [official migration guide](https://github.com/rrousselGit/freezed/blob/master/packages/freezed/migration_guide.md).

### Changes Made
- Updated class generation syntax **from**:
  ```dart
  private fun StringBuilder.appendEntity(entity: Entity) {
        with(entity) {
            ...
            append("class $type with _\$$type {\n")

- Updated class generation syntax **to**:
  ```dart
  private fun StringBuilder.appendEntity(entity: Entity) {
        with(entity) {
            ...
            append("abstract class $type with _\$$type {\n")
